### PR TITLE
Fix the .csproj file to include proper filenames

### DIFF
--- a/OsuMapDownload/OsuMapDownload.csproj
+++ b/OsuMapDownload/OsuMapDownload.csproj
@@ -46,8 +46,8 @@
     <Compile Include="Exceptions\DownloadProviderNotReadyException.cs" />
     <Compile Include="Exceptions\MapsetDownloadInterrupedException.cs" />
     <Compile Include="Exceptions\MapsetNotFoundException.cs" />
-    <Compile Include="Models\MapsetDownload.cs" />
-    <Compile Include="Models\MapsetExtractDownload.cs" />
+    <Compile Include="Models\MapSetDownload.cs" />
+    <Compile Include="Models\MapSetExtractDownload.cs" />
     <Compile Include="Providers\B1oodcatDownloadProvider.cs" />
     <Compile Include="Providers\BeatmapDownloadProvider.cs" />
     <Compile Include="Bloodcat.cs" />


### PR DESCRIPTION
The filenames are not proper and causes travis-ci build to break on https://github.com/otaku-overclocks/osu-collection-explorer/